### PR TITLE
fix: downgrade erlang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG ERLANG_VERSION=22.3.4.26
 
 # renovate: datasource=github-releases depName=elixir lookupName=elixir-lang/elixir
-ARG ELIXIR_VERSION=v1.13.4
+ARG ELIXIR_VERSION=1.13.4
 
 FROM ghcr.io/containerbase/buildpack:4.7.2@sha256:bdf5e7b058f80acb094b115b87e34c29cf17b1e4cfa92e531846477c8580bc97
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG ERLANG_VERSION=22.3.4.26
 
 # renovate: datasource=github-releases depName=elixir lookupName=elixir-lang/elixir
-ARG ELIXIR_VERSION=1.13.4
+ARG ELIXIR_VERSION=v1.13.4
 
 FROM ghcr.io/containerbase/buildpack:4.7.2@sha256:bdf5e7b058f80acb094b115b87e34c29cf17b1e4cfa92e531846477c8580bc97
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+# https://hexdocs.pm/elixir/1.13.4/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
+# we rebuild from 1.8.2, so we are stuck on v22
+
 # renovate: datasource=github-releases depName=erlang lookupName=containerbase/erlang-prebuild versioning=loose
-ARG ERLANG_VERSION=24.3.4.2
+ARG ERLANG_VERSION=22.3.4.26
 
 # renovate: datasource=docker depName=elixir versioning=docker
 ARG ELIXIR_VERSION=1.13.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 # renovate: datasource=github-releases depName=erlang lookupName=containerbase/erlang-prebuild versioning=loose
 ARG ERLANG_VERSION=22.3.4.26
 
-# renovate: datasource=docker depName=elixir versioning=docker
+# renovate: datasource=github-releases depName=elixir lookupName=elixir-lang/elixir
 ARG ELIXIR_VERSION=1.13.4
 
-FROM renovate/buildpack:6@sha256:bee65d1f1bd568bf292f22cd4f39e60e3bf44966f76069d68d11cc49c6165e67
+FROM ghcr.io/containerbase/buildpack:4.7.2@sha256:bdf5e7b058f80acb094b115b87e34c29cf17b1e4cfa92e531846477c8580bc97
 
 ARG ERLANG_VERSION
 RUN install-tool erlang
@@ -17,5 +17,8 @@ RUN install-tool elixir
 
 LABEL org.opencontainers.image.source="https://github.com/renovatebot/docker-elixir" \
       org.opencontainers.image.version="${ELIXIR_VERSION}"
+
+# workaround for old renovate
+RUN ln -sf /home/user /home/ubuntu && ls -la /home/ubuntu/
 
 USER 1000

--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,6 @@
 {
   "image": "elixir",
   "startVersion": "1.8.2",
+  "extractVersion": "^v(?<version>.*)$",
   "cache": "docker-build-cache"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>renovatebot/.github"]
+  "extends": ["github>renovatebot/.github"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["elixir-lang/elixir", "elixir"],
+      "matchDatasources": ["github-releases"],
+      "extractVersion": "^v(?<version>.+)$"
+    }
+  ]
 }


### PR DESCRIPTION
we rebuild images from elixir 1.8.2, so we are stuck on v22 of erlang